### PR TITLE
Do not register drag and scale for Undo

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
@@ -253,9 +253,9 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
                 mPath.lineTo(mCurX + 1, mCurY + 2)
                 mPath.lineTo(mCurX + 1, mCurY)
             }
+            mPaths[mPath] = mPaintOptions
         }
 
-        mPaths[mPath] = mPaintOptions
         pathsUpdated()
         mPath = MyPath()
         mPaintOptions = PaintOptions(mPaintOptions.color, mPaintOptions.strokeWidth, mPaintOptions.isEraser)


### PR DESCRIPTION
**Notes**
- Only add paths when it was not a multi-touch in order to exclude scale and drag for undo/redo functionality
- Closes #203 