### PR TITLE
Zoom towards the center of the screen

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
@@ -408,6 +408,12 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
             mWasScalingInGesture = true
             mScaleFactor *= detector.scaleFactor
             mScaleFactor = max(0.1f, min(mScaleFactor, 10.0f))
+
+            if (mScaleFactor < 10.0f && mScaleFactor > 0.1f) {
+                mPosX *= detector.scaleFactor
+                mPosY *= detector.scaleFactor
+            }
+
             setBrushSize(mCurrBrushSize)
             invalidate()
             return true


### PR DESCRIPTION
This helps fix #138 and #166.

The old zoom behaviour means that when you zoom in after moving the canvas, you end up zooming away from what you were recently drawing. In other words, the center of the zoom was at (0, 0) or the original center of the image.

This PR fixes that by adjusting the canvas position based of how much is zoomed so that the zoom is focused towards the center of what you can see (the screen) - fixing any weirdness with the zoom that was after moving.

