### PR TITLE
Fix abrupt multitouch movement

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
@@ -64,6 +64,7 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
     private var mIsBucketFillOn = false
     private var mWasMultitouch = false
     private var mIgnoreTouches = false
+    private var mIgnoreMultitouchChanges = false
     private var mWasScalingInGesture = false
     private var mWasMovingCanvasInGesture = false
     private var mBackgroundColor = 0
@@ -168,7 +169,7 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
                     actionMove(newValueX, newValueY)
                 }
 
-                if (mAllowMovingZooming && mWasMultitouch) {
+                if (mAllowMovingZooming && mWasMultitouch && !mIgnoreMultitouchChanges) {
                     mPosX += x - mLastTouchX
                     mPosY += y - mLastTouchY
                     mWasMovingCanvasInGesture = true
@@ -177,6 +178,7 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
                 mLastTouchX = x
                 mLastTouchY = y
+                mIgnoreMultitouchChanges = false
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 mActivePointerId = INVALID_POINTER_ID
@@ -187,12 +189,14 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
             MotionEvent.ACTION_POINTER_DOWN -> {
                 if (mAllowMovingZooming) {
                     mWasMultitouch = true
+                    mIgnoreMultitouchChanges = true
                     mTouchSloppedBeforeMultitouch = mLastMotionEvent.isTouchSlop(pointerIndex, mStartX, mStartY)
                 }
             }
             MotionEvent.ACTION_POINTER_UP -> {
                 if (mAllowMovingZooming) {
                     mIgnoreTouches = true
+                    mIgnoreMultitouchChanges = true
                     actionUp(!mWasScalingInGesture && !mWasMovingCanvasInGesture)
                 }
             }


### PR DESCRIPTION
This is a proposed solution that should fix #268.

The issue seems to be `mLastTouchX` and `mLastTouchY`, because once one of the two fingers is released `x` and `y` [get set](https://github.com/SimpleMobileTools/Simple-Draw/blob/d84906bf9c5f866e70b44904c5d516b5c2ee6214/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt#L132-L133) to the coordinates of the remaining finger, while `mLastTouchX` and `mLastTouchY` are left unchanged with the coordinates of the other finger. Because of this, when the canvas position is updated, it ends up moving abruptly.

This solution simply consists of skipping the one [update](https://github.com/SimpleMobileTools/Simple-Draw/blob/d84906bf9c5f866e70b44904c5d516b5c2ee6214/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt#L172-L173) after the finger is released, so that `mLastTouchX` and `mLastTouchY` are correctly updated to the remaining finger before updating the canvas position.