### PR TITLE
Decrease flood fill tolerance to 1

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
@@ -28,7 +28,7 @@ import kotlin.math.min
 class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
     private val MIN_ERASER_WIDTH = 20f
     private val MAX_HISTORY_COUNT = 1000
-    private val FLOOD_FILL_TOLERANCE = 10
+    private val FLOOD_FILL_TOLERANCE = 1
 
     private val mScaledTouchSlop = ViewConfiguration.get(context).scaledTouchSlop
 


### PR DESCRIPTION
This allows flood-filling shapes made with very light-colored strokes. Example: #FFF9FF on #FFFFFF