### PR TITLE
Add a relative brush size option

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/activities/MainActivity.kt
@@ -144,6 +144,7 @@ class MainActivity : SimpleActivity(), CanvasListener {
         stroke_width_bar.beVisibleIf(isShowBrushSizeEnabled)
         stroke_width_preview.beVisibleIf(isShowBrushSizeEnabled)
         my_canvas.setAllowZooming(config.allowZoomingCanvas)
+        my_canvas.setRelativeBrushSize(config.relativeBrushSize)
         updateTextColors(main_holder)
         if (isBlackAndWhiteTheme()) {
             stroke_width_bar.setColors(0, config.canvasBackgroundColor.getContrastColor(), 0)

--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/activities/SettingsActivity.kt
@@ -31,6 +31,7 @@ class SettingsActivity : SimpleActivity() {
         setupPreventPhoneFromSleeping()
         setupBrushSize()
         setupAllowZoomingCanvas()
+        setupRelativeBrushSize()
         setupForcePortraitMode()
         updateTextColors(settings_holder)
 
@@ -84,6 +85,14 @@ class SettingsActivity : SimpleActivity() {
         settings_allow_zooming_canvas_holder.setOnClickListener {
             settings_allow_zooming_canvas.toggle()
             config.allowZoomingCanvas = settings_allow_zooming_canvas.isChecked
+        }
+    }
+
+    private fun setupRelativeBrushSize() {
+        settings_relative_brush_size.isChecked = config.relativeBrushSize
+        settings_relative_brush_size_holder.setOnClickListener {
+            settings_relative_brush_size.toggle()
+            config.relativeBrushSize = settings_relative_brush_size.isChecked
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/helpers/Config.kt
@@ -38,6 +38,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getBoolean(ALLOW_ZOOMING_CANVAS, true)
         set(allowZoomingCanvas) = prefs.edit().putBoolean(ALLOW_ZOOMING_CANVAS, allowZoomingCanvas).apply()
 
+    var relativeBrushSize: Boolean
+        get() = prefs.getBoolean(RELATIVE_BRUSH_SIZE, true)
+        set(relativeBrushSize) = prefs.edit().putBoolean(RELATIVE_BRUSH_SIZE, relativeBrushSize).apply()
+
     var forcePortraitMode: Boolean
         get() = prefs.getBoolean(FORCE_PORTRAIT_MODE, false)
         set(forcePortraitMode) = prefs.edit().putBoolean(FORCE_PORTRAIT_MODE, forcePortraitMode).apply()

--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/helpers/Constants.kt
@@ -7,6 +7,7 @@ const val BRUSH_SIZE = "brush_size_2"
 const val LAST_SAVE_FOLDER = "last_save_folder"
 const val LAST_SAVE_EXTENSION = "last_save_extension"
 const val ALLOW_ZOOMING_CANVAS = "allow_zooming_canvas"
+const val RELATIVE_BRUSH_SIZE = "relative_brush_size"
 const val FORCE_PORTRAIT_MODE = "force_portrait_mode"
 
 const val PNG = "png"

--- a/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/draw/pro/views/MyCanvas.kt
@@ -54,6 +54,7 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     private var mCurrBrushSize = 0f
     private var mAllowMovingZooming = true
+    private var mRelativeBrushSize = true
     private var mIsEraserOn = false
     private var mIsBucketFillOn = false
     private var mWasMultitouch = false
@@ -278,11 +279,19 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     fun setBrushSize(newBrushSize: Float) {
         mCurrBrushSize = newBrushSize
-        mPaintOptions.strokeWidth = resources.getDimension(R.dimen.full_brush_size) * (mCurrBrushSize / mScaleFactor / 100f)
+        mPaintOptions.strokeWidth = resources.getDimension(R.dimen.full_brush_size) * (mCurrBrushSize / 100f)
+        if (mRelativeBrushSize) {
+            mPaintOptions.strokeWidth /= mScaleFactor
+        }
     }
 
     fun setAllowZooming(allowZooming: Boolean) {
         mAllowMovingZooming = allowZooming
+    }
+
+    fun setRelativeBrushSize(relativeBrushSize: Boolean) {
+        mRelativeBrushSize = relativeBrushSize
+        setBrushSize(mCurrBrushSize)
     }
 
     fun getBitmap(): Bitmap {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -147,6 +147,21 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/settings_relative_brush_size_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_relative_brush_size"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/use_relative_brush_size" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/settings_force_portrait_holder"
                 style="@style/SettingsHolderCheckboxStyle"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <!-- Settings -->
     <string name="show_brush_size">Show brush size tool</string>
     <string name="allow_zooming_moving_canvas">Allow zooming and moving the canvas with gestures</string>
+    <string name="use_relative_brush_size">Use a relative (to zoom) brush size</string>
     <string name="clear">Clear</string>
     <string name="change_background_color">Change background color</string>
     <!--


### PR DESCRIPTION
Relative brush sizing can be annoying/difficult in certain situations, such as when trying to draw a picture with consistent line width.

This PR adds an option to disable relative brush size (enabled by default to preserve normal behaviour)